### PR TITLE
Corrige texto de exemplo

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,8 +24,8 @@
           <p>You will need use our markup style but it's so easy...
             Well... you will use "- " for issue title, "> " for issue description and "# " for issue labels (multiple labels will be separated by comma). Eg:</p>
             <div class="code-block cmd text-left">
-              <h2>- As user i want to logon on system</h2>
-              <p>> The user will logon with email and password</p>
+              <h2>- As user i want to login on system</h2>
+              <p>> The user will login with email and password</p>
               <p><b># user,essential</b> </p>
             </div>
             <div class="inform warning">


### PR DESCRIPTION
Invés de "Logon", o correto seria "Login", já que o especificado é usar email e senha.