### PR TITLE
Corrige altura do select

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -286,4 +286,7 @@
 .detail {
   font-weight: bold; }
 
+#platform {
+  height: 31px; }
+
 /*# sourceMappingURL=style.css.map */


### PR DESCRIPTION
No navegador Chrome Versão 66.0.3359.181 (Versão oficial) 64 bits, o select aparece com altura de 18px. A correção adiciona 31px como altura do select, a mesmo dos inputs.

Antes:
![image](https://user-images.githubusercontent.com/7275870/40587002-0273ef40-61a0-11e8-9b3a-9dd6b6ae3e06.png)

Depois:
![image](https://user-images.githubusercontent.com/7275870/40587013-24d3b5b6-61a0-11e8-8f86-df04551cae0d.png)
